### PR TITLE
Deployment system using docker and dokku-alt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+MAINTAINER tuxedio
+
 FROM nginx
 COPY . /usr/share/nginx/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx
+COPY . /usr/share/nginx/html
+
+EXPOSE 5000

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -461,19 +461,41 @@ module.exports = function (grunt) {
       server: [
         'coffee:server',
         'compass:server',
-        'jade:server'
+        'jade:server',
+        'ngconstant:server'
       ],
       test: [
         'coffee:test',
-        'compass'
+        'compass',
+        'ngconstant:server'
       ],
       dist: [
         'coffee:dist',
         'compass:dist',
         'imagemin',
         'jade:dist',
-        'svgmin'
+        'svgmin',
+        'ngconstant:dist'
       ]
+    },
+
+    // Automatically create ng-constants file for api connection
+    ngconstant: {
+      options: {
+        name: 'tuxedioFrontendApp.constants',
+        dest: '.tmp/scripts/constants/config.js',
+        wrap: true
+      },
+      server:{
+        constants: {
+          API_URL: "v1/"
+        }
+      },
+      dist: {
+        constants: {
+          API_URL: "http://api.tuxedio.com/v1/"
+        }
+      }
     },
 
     // Test settings

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,9 @@ module.exports = function (grunt) {
     dist: 'dist'
   };
 
+  //define pkg for use in deployment versioning
+  var pkg = require('./package.json');
+
   // Define the configuration for all the tasks
   grunt.initConfig({
 
@@ -154,7 +157,7 @@ module.exports = function (grunt) {
           src: [
             '.tmp',
             '<%= yeoman.dist %>/{,*/}*',
-            '!<%= yeoman.dist %>/.git*'
+            '!<%= yeoman.dist %>/.git{,*/}*'
           ]
         }]
       },
@@ -445,7 +448,10 @@ module.exports = function (grunt) {
           expand: true,
           cwd: '.',
           dest: '<%= yeoman.dist %>',
-          src: 'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*'
+          src: [
+            'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*',
+            'Dockerfile'
+          ]
         }]
       },
       styles: {
@@ -494,6 +500,22 @@ module.exports = function (grunt) {
       dist: {
         constants: {
           API_URL: "http://api.tuxedio.com/v1/"
+        }
+      }
+    },
+
+    buildcontrol: {
+      options: {
+        dir: 'dist',
+        commit: true,
+        push: true,
+        message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch%'
+      },
+      dokku: {
+        options: {
+          remote: 'dokku@tuxedio.com:www',
+          branch: 'master',
+          tag: pkg.version
         }
       }
     },
@@ -547,6 +569,12 @@ module.exports = function (grunt) {
     'filerev',
     'usemin',
     // 'htmlmin'
+  ]);
+
+  grunt.registerTask('deploy', [
+    'test',
+    'build',
+    'buildcontrol'
   ]);
 
   grunt.registerTask('default', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -509,13 +509,12 @@ module.exports = function (grunt) {
         dir: 'dist',
         commit: true,
         push: true,
-        message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch%'
+        message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch% ' + pkg.version
       },
       dokku: {
         options: {
           remote: 'dokku@tuxedio.com:www',
-          branch: 'master',
-          tag: pkg.version
+          branch: 'master'
         }
       }
     },

--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -16,7 +16,8 @@ angular
     'ngResource',
     'ngRoute',
     'ngSanitize',
-    'ngTouch'
+    'ngTouch',
+    'tuxedioFrontendApp.constants'
   ])
 
   # Routes
@@ -33,9 +34,6 @@ angular
         controller: 'AdminCtrl'
       .otherwise
         redirectTo: '/'
-
-  # App Constants
-  .constant('API_URL', 'v1/')
 
   # CSRF Authentication
   .config ($httpProvider) ->

--- a/app/scripts/controllers/admin.coffee
+++ b/app/scripts/controllers/admin.coffee
@@ -12,8 +12,8 @@ angular.module('tuxedioFrontendApp')
 
     # Initialize controller
     init = () ->
-      $scope.experiences = Experience.index()
-
+      Experience.index().$promise.then (data) ->
+       $scope.experiences = data.experiences
     # Delete experience by ID and update list
     $scope.delete = (expId) ->
       Experience.destroy({id: expId})

--- a/app/scripts/services/experience.coffee
+++ b/app/scripts/services/experience.coffee
@@ -13,7 +13,7 @@ angular.module('tuxedioFrontendApp')
       return $resource(API_URL + "experiences/:id", { id: "@id" },
         {
           'create':  { method: 'POST' },
-          'index':   { method: 'GET', isArray: true },
+          'index':   { method: 'GET' },
           'show':    { method: 'GET', isArray: false },
           'update':  { method: 'PUT' },
           'destroy': { method: 'DELETE' }

--- a/app/views/admin.jade
+++ b/app/views/admin.jade
@@ -1,5 +1,4 @@
 h1 Admin Page
-
 div
   table.table-striped.table
     tr
@@ -12,8 +11,8 @@ div
       th
         strong &nbsp;
     tr(ng-repeat="exp in experiences")
-      td {{exp.experience.name}}
-      td {{exp.experience.location}}
-      td {{exp.experience.description}}
+      td {{exp.name}}
+      td {{exp.location}}
+      td {{exp.description}}
       td
         button(ng-click='delete("{{exp.experience.id}}")') Delete Entry

--- a/app/views/includes/scripts.jade
+++ b/app/views/includes/scripts.jade
@@ -45,6 +45,7 @@ script(src='bower_components/angular-route/angular-route.js')
 
 <!-- build:js({.tmp,app}) scripts/scripts.js -->
 script(src="scripts/app.js")
+script(src="scripts/constants/config.js")
 script(src="scripts/controllers/main.js")
 script(src="scripts/controllers/about.js")
 script(src="scripts/controllers/admin.js")

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "tuxediofrontend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.8.0",
     "grunt": "^0.4.1",
     "grunt-autoprefixer": "^0.7.3",
+    "grunt-build-control": "^0.1.8",
     "grunt-concurrent": "^0.5.0",
     "grunt-connect-proxy": "^0.1.11",
     "grunt-contrib-clean": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-karma": "^0.8.3",
     "grunt-newer": "^0.7.0",
     "grunt-ng-annotate": "^0.3.0",
+    "grunt-ng-constant": "^1.0.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,19 @@ Tuxedio Angular Frontend
   2. Try to stay consistent in coding styles
   3. Use 2 spaces for tabbing
   4. Align characters when possible. (tip: use a monospaced font like Inconsolata)
-  5. Naming conventions: 
+  5. Naming conventions:
     - Modules: lowerCamelCase
     - Controllers: UpperCamelCase (eg: "MyCtrl")
     - Directives: lowerCamel Case
     - Services: UpperCamelCase (singular similar to rails modules)
   6. Comment about WHAT your code does, not HOW. If someone else can't understand the logic, you might want to refactor your code...
+
+
+###Deploy to dokku:
+  1. Add ssh key to dokku
+
+    ```
+      $ cat ~/.ssh/id_rsa.pub | ssh root@<domian-name> "sudo sshcommand acl-add dokku <your-name>"
+    ```
+  2. Ensure Gruntfile buildcontrol is set to the correct dokku git repo
+  3. Run ```grunt deploy```

--- a/test/karma.conf.coffee
+++ b/test/karma.conf.coffee
@@ -22,6 +22,7 @@ module.exports = (config) ->
       'bower_components/angular-route/angular-route.js'
       'bower_components/angular-sanitize/angular-sanitize.js'
       'bower_components/angular-touch/angular-touch.js'
+      '.tmp/scripts/constants/config.js'
       'app/scripts/**/*.coffee'
       'test/mock/**/*.coffee'
       'test/spec/**/*.coffee'

--- a/test/spec/controllers/admin.coffee
+++ b/test/spec/controllers/admin.coffee
@@ -2,21 +2,41 @@
 
 describe 'Controller: AdminCtrl', ->
 
+  $q = {}
+  $rootScope = {}
+  $scope = {}
+  mockExperience = {}
+  mockExperienceResponse = {"experiences":[{"id":1},{"id":2}]}
+  queryDeferred = {}
+
   # load the controller's module
   beforeEach module 'tuxedioFrontendApp'
 
-  AdminCtrl = {}
-  scope = {}
-  Experience = {}
+  beforeEach inject ($controller, _$q_, _$rootScope_) ->
+    $q = _$q_
+    $rootScope = _$rootScope_
+    $scope = $rootScope.$new()
 
-  # Initialize the controller and a mock scope
-  beforeEach inject ($controller, $rootScope, _Experience_) ->
-    scope = $rootScope.$new()
-    Experience = _Experience_
-    spyOn(Experience, 'index').andReturn([{"id":1},{"id":2}])
-    AdminCtrl = $controller 'AdminCtrl', {
-      $scope: scope
+    mockExperience = {
+      index:  ->
+        queryDeferred = $q.defer()
+        return {$promise: queryDeferred.promise}
     }
 
+    spyOn(mockExperience, 'index').andCallThrough()
+
+    $controller('AdminCtrl', {
+      '$scope': $scope,
+      'Experience': mockExperience
+    })
+
+
+  beforeEach ->
+    queryDeferred.resolve(mockExperienceResponse)
+    $rootScope.$apply()
+
+  it 'should query the Experience service', ->
+    expect(mockExperience.index).toHaveBeenCalled();
+
   it 'should attach a list of experiences to the scope', ->
-    expect(scope.experiences).toEqual([{"id":1},{"id":2}])
+    expect($scope.experiences).toEqual([{"id":1},{"id":2}])

--- a/test/spec/services/experience.coffee
+++ b/test/spec/services/experience.coffee
@@ -9,21 +9,27 @@ describe 'Service: Experience', ->
   Experience = {}
   $httpBackend = {}
   API_URL = {}
+  result = {}
 
   beforeEach inject ($injector, _API_URL_) ->
     $httpBackend = $injector.get('$httpBackend')
     Experience = $injector.get('Experience')
     API_URL = _API_URL_
 
-  it 'should return a list of experiences when index is called', ->
-    experiencelist = [ { experience : { name : "Experience 1" } },
-                       { experience : { name : "Experience 2" } },
-                       { experience : { name : "Experience 3" }}
-                     ]
+    # Create sample data
+    experiencelist = {experiences: [
+      { experience : { name : "Experience 1" } },
+      { experience : { name : "Experience 2" } },
+      { experience : { name : "Experience 3" }}
+    ]}
+
+    # Mock the httpBackend function and store resulting array
     $httpBackend.expectGET(API_URL + 'experiences')
                 .respond(experiencelist)
-
-    result = Experience.index()
+    Experience.index().$promise.then (data) ->
+      result = data.experiences
     $httpBackend.flush()
+
+  it 'should return a list of experiences when index is called', ->
     expect(result[0].experience.name).toEqual "Experience 1"
     expect(result.length).toBe 3


### PR DESCRIPTION
This PR updates the API_URL constant to point to api.tuxedio.com when deploying, and localhost otherwise.
It also creates a deployment system for dokku-alt. 
Run 'grunt deploy' to test, build, and deploy to dokku-alt 'www' subdomain. Grunt will automatically create a git repository and move the Dockerfile into the dist/ folder, allowing for a smooth deploy.

As a heads up, we receive the following error due to the tagging system. Deploys still work correctly, dokku simply doesn't know how to deploy tags, so it complains. Here is the error:
```
To dokku@104.236.181.187:www
 * [new branch]      master -> master
-----> WARNING: deploy did not complete, you must push to master.
-----> for example, try 'git push <dokku> refs/tags/0.0.1:master'
To dokku@104.236.181.187:www
 * [new tag]         0.0.1 -> 0.0.1
```
Three solutions: 
  1. Remove the tagging through buildcontrol
  2. Fix dokku-alt so it stops complaining
  3. Ignore the error