### PR TITLE
Fix style errors and add coffeelint to test suite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -525,9 +525,13 @@ module.exports = function (grunt) {
         configFile: 'test/karma.conf.coffee',
         singleRun: true
       }
+    },
+
+    coffeelint: {
+      app: ['app/**/*.coffee'],
+      tests: ['tests/**/*.coffee']
     }
   });
-
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
     if (target === 'dist') {
@@ -581,4 +585,6 @@ module.exports = function (grunt) {
     'test',
     'build'
   ]);
+
+  grunt.registerTask('lint', ['coffeelint']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -473,6 +473,7 @@ module.exports = function (grunt) {
       test: [
         'coffee:test',
         'compass',
+        'coffeelint',
         'ngconstant:server'
       ],
       dist: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,13 @@ module.exports = function (grunt) {
         files: ['<%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
         tasks: ['newer:coffee:server', 'karma']
       },
+      coffeelint:{
+        files: [
+          '<%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}',
+          'test/{,*/}*.{coffee,litcoffee,coffee.md}'
+        ],
+        tasks: ['coffeelint']
+      },
       coffeeTest: {
         files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
         tasks: ['newer:coffee:test', 'karma']

--- a/app/scripts/controllers/admin.coffee
+++ b/app/scripts/controllers/admin.coffee
@@ -13,7 +13,7 @@ angular.module('tuxedioFrontendApp')
     # Initialize controller
     init = () ->
       Experience.index().$promise.then (data) ->
-       $scope.experiences = data.experiences
+        $scope.experiences = data.experiences
 
     # Delete experience by ID and update list
     $scope.delete = (expId) ->

--- a/app/scripts/services/auth_intercepter.coffee
+++ b/app/scripts/services/auth_intercepter.coffee
@@ -1,22 +1,23 @@
 'use strict'
 
 ###*
- # @ngdoc service
- # @name tuxedioFrontendApp.authIntercepter
- # @description
- # # authentication
- # Factory in the tuxedioFrontendApp.
+# @ngdoc service
+# @name tuxedioFrontendApp.authIntercepter
+# @description
+# # authentication
+# Factory in the tuxedioFrontendApp.
 ###
 angular.module('tuxedioFrontendApp')
   .factory 'authIntercepter', ($rootScope, $q, AuthToken) ->
-      #intercept Request to add authentication token to header
-      request: (config) ->
-        config.headers = config.headers || {}
-        authToken = AuthToken.getToken()
-        if authToken then config.headers.Authentication = 'Bearer ' + authToken
-        return config
 
-      # Error Handler
-      responseError: (rejection) ->
-        # TODO: 401 response handler
-        return $q.reject(rejection)
+    # Intercept Request to add authentication token to header
+    request: (config) ->
+      config.headers = config.headers || {}
+      authToken = AuthToken.getToken()
+      if authToken then config.headers.Authentication = 'Bearer ' + authToken
+      config
+
+    # Error Handler
+    responseError: (rejection) ->
+      # TODO: 401 response handler
+      $q.reject(rejection)

--- a/app/scripts/services/auth_token.coffee
+++ b/app/scripts/services/auth_token.coffee
@@ -1,29 +1,24 @@
 'use strict'
 
 ###*
- # @ngdoc service
- # @name tuxedioFrontendApp.AuthTokenFactory
- # @description
- # # AuthTokenFactory
- # Factory in the tuxedioFrontendApp.
+# @ngdoc service
+# @name tuxedioFrontendApp.AuthTokenFactory
+# @description
+# # AuthTokenFactory
+# Factory in the tuxedioFrontendApp.
 ###
 angular.module('tuxedioFrontendApp')
   .factory 'AuthToken', ($window) ->
-      store = $window.localStorage
-      key = 'auth-token'
+    store = $window.localStorage
+    key = 'auth-token'
 
-      getToken =  ->
-        store.getItem(key)
+    getToken =  ->
+      store.getItem(key)
 
-      setToken = (token) ->
-        if (token)
-          store.setItem(key, token)
-        else
-          store.removeItem(key)
+    setToken = (token) ->
+      if (token)
+        store.setItem(key, token)
+      else
+        store.removeItem(key)
 
-      return {
-        getToken: getToken,
-        setToken: setToken
-      }
-
-
+    { getToken: getToken, setToken: setToken }

--- a/app/scripts/services/session.coffee
+++ b/app/scripts/services/session.coffee
@@ -9,25 +9,23 @@
 ###
 angular.module('tuxedioFrontendApp')
   .factory 'Session', ($http, AuthToken, API_URL) ->
-      authenticate = (login) ->
-        $http
-        .post(API_URL + 'login.json', login)
-        .success (data, status, headers, config) ->
-          AuthToken.setToken(data.token)
-        .error (data, status, headers, config) ->
-          # Remove token if user fails to log in
-          AuthToken.setToken()
-
-      unauthenticate = ->
+    authenticate = (login) ->
+      $http
+      .post(API_URL + 'login.json', login)
+      .success (data, status, headers, config) ->
+        AuthToken.setToken(data.token)
+      .error (data, status, headers, config) ->
+        # Remove token if user fails to log in
         AuthToken.setToken()
 
-      authenticated = ->
-        if AuthToken.getToken() then true else false
+    unauthenticate = ->
+      AuthToken.setToken()
 
-      return {
-        authenticate: authenticate,
-        unauthenticate: unauthenticate,
-        authenticated: authenticated
-      }
+    authenticated = ->
+      if AuthToken.getToken() then true else false
 
-
+    return {
+      authenticate: authenticate,
+      unauthenticate: unauthenticate,
+      authenticated: authenticated
+    }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.8.0",
+    "coffeelint": "^1.8.1",
     "grunt": "^0.4.1",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-build-control": "^0.1.8",
+    "grunt-coffeelint": "0.0.13",
     "grunt-concurrent": "^0.5.0",
     "grunt-connect-proxy": "^0.1.11",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
I like to use style linters when writing code. They offer some nice easy to use
ways to write more concise, consistent code. I think using them in a test suite
is very important as it creates for consistent code, and it allows for code
reviewers to focus on the content of the PR as opposed to style nitpicks.

@thejinxters, you down?